### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/th-extras.cabal
+++ b/th-extras.cabal
@@ -2,7 +2,7 @@ name:                   th-extras
 version:                0.0.0.4
 stability:              experimental
 
-cabal-version:          >= 1.6
+cabal-version:          >= 1.8
 build-type:             Simple
 
 author:                 James Cook <mokus@deepbondi.net>


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: th-extras.cabal:35:37: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```