### PR TITLE
Fix GHC 8.0 build

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1']
+        ghc: ['8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.2', '9.0.1']
         os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
 

--- a/src/Language/Haskell/TH/Extras.hs
+++ b/src/Language/Haskell/TH/Extras.hs
@@ -195,8 +195,10 @@ substVarsWith topVars resultType argType = subst Set.empty argType
       InfixT t1 x t2 -> InfixT (subst bs t1) x (subst bs t2)
       ParensT t -> ParensT (subst bs t)
       UInfixT t1 x t2 -> UInfixT (subst bs t1) x (subst bs t2)
-      UnboxedSumT k -> UnboxedSumT k
       WildCardT -> WildCardT
+#endif
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 802
+      UnboxedSumT k -> UnboxedSumT k
 #endif
 #if defined (__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 710
       EqualityT -> EqualityT

--- a/th-extras.cabal
+++ b/th-extras.cabal
@@ -32,7 +32,7 @@ source-repository head
 Library
   hs-source-dirs:       src
   exposed-modules:      Language.Haskell.TH.Extras
-  build-depends:        base >= 4.10 && < 5
+  build-depends:        base >= 4.9 && < 5
                       , containers
                       , template-haskell < 2.18
                       , th-abstraction >= 0.4 && < 0.5


### PR DESCRIPTION
I normally wouldn't bother, but since we can hopefully deprecate this
pacakage soon, and some downstream packages still CI 8.0, seems like a
fine thing to end on.