### PR TITLE
th abstraction 0.7

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -22,7 +22,7 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-update: true
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-cabal
       with:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,8 @@
 name: haskell
 
-on: [push, pull_request]
+on:
+  push:         { branches: [master] }
+  pull_request: { branches: [master] }
 
 jobs:
   build:
@@ -15,30 +17,37 @@ jobs:
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }}
     steps:
+
     - uses: actions/checkout@v4
+
     - uses: haskell-actions/setup@v2
       id:   setup
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-update: true
-    - name: Cache
-      uses: actions/cache@v4
+
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      id: cache
       env:
-        cache-name: cache-cabal
+        key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-build-
-          ${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-
-          ${{ runner.os }}
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ env.key }}-commit-${{ github.sha }}
+        restore-keys: ${{ env.key }}-
 
     - name: Install dependencies
       run: cabal build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
-      run: cabal build --enable-tests --enable-benchmarks all
+      run: cabal build --enable-tests --enable-benchmarks
     - name: Run tests
-      run: cabal test --enable-tests  --enable-benchmarks all
+      run: cabal test --enable-tests  --enable-benchmarks
     - name: Build Docs
       run: cabal haddock --disable-documentation
+
+    - name: Cache dependencies
+      uses: actions/cache/save@v4
+      if: always() && steps.cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for th-extras
 
+## 0.0.0.7 - 2023-12-15
+
+* Support GHC 9.6 and 9.8
+
 ## 0.0.0.6 - 2022-01-04
 
 * Fix GHC 8.0 build

--- a/th-extras.cabal
+++ b/th-extras.cabal
@@ -18,9 +18,18 @@ description:            A grab bag of functions for use with Template Haskell.
                         the ever-changing interface of the template haskell system by
                         providing high-level operations and making sure they work on as many
                         versions of Template Haskell as I can.
-
-tested-with:            GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4,
-                        GHC == 8.10.2, GHC == 9.0.1, GHC == 9.6.3, GHC == 9.8.1
+tested-with:
+                        GHC == 9.8.2
+                        GHC == 9.6.4
+                        GHC == 9.4.8
+                        GHC == 9.2.8
+                        GHC == 9.0.2
+                        GHC == 8.10.7
+                        GHC == 8.8.4
+                        GHC == 8.6.5
+                        GHC == 8.4.4
+                        GHC == 8.2.2
+                        GHC == 8.0.2
 
 extra-source-files:     ReadMe.md
                       , ChangeLog.md

--- a/th-extras.cabal
+++ b/th-extras.cabal
@@ -1,5 +1,5 @@
 name:                   th-extras
-version:                0.0.0.6
+version:                0.0.0.7
 stability:              experimental
 
 cabal-version:          >= 1.10
@@ -19,8 +19,8 @@ description:            A grab bag of functions for use with Template Haskell.
                         providing high-level operations and making sure they work on as many
                         versions of Template Haskell as I can.
 
-tested-with:            GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5,
-                        GHC == 8.8.4, GHC == 8.10.2, GHC == 9.0.1
+tested-with:            GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4,
+                        GHC == 8.10.2, GHC == 9.0.1, GHC == 9.6.3, GHC == 9.8.1
 
 extra-source-files:     ReadMe.md
                       , ChangeLog.md

--- a/th-extras.cabal
+++ b/th-extras.cabal
@@ -44,6 +44,6 @@ Library
   build-depends:        base >= 4.9 && < 5
                       , containers
                       , template-haskell < 2.23
-                      , th-abstraction >= 0.4 && < 0.7
+                      , th-abstraction >= 0.4 && < 0.8
                       , syb
   default-language:     Haskell2010


### PR DESCRIPTION
- **CI: bump cache action to v4**
- **cabal file: update tested-with**
- **Allow th-abstraction-0.7**

Adresses:
- https://github.com/commercialhaskell/stackage/issues/7352

@erikd Maybe you could add yourself as stackage maintainer for `th-abstraction`?  It is currently "grandfathered", meaning no contact person.
